### PR TITLE
ignore IDE, build, and .gradle dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,28 @@
 *.zip
 *.tar.gz
 *.rar
-.gradle/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
 
-#IDE Files #
+# Gradle directories
+.gradle/
+ 
+# Visual Studio Code
 .vscode/
+
+# Build output
+build/
+ 
+# IntelliJ IDEA
+.idea/
+*.iml
+ 
+# Eclipse IDE
+.settings/
+.classpath
+.project
+
+# macOS-specific file
+.DS_Store


### PR DESCRIPTION
included ignores for: 
# Gradle directories
.gradle/
 
# Visual Studio Code
.vscode/

# Build output
build/
 
# IntelliJ IDEA
.idea/
*.iml
 
# Eclipse IDE
.settings/
.classpath
.project

# macOS-specific file
.DS_Store