### PR TITLE
docs: complete Sprint 0 agent foundation

### DIFF
--- a/docs/adr/0003-use-explicit-membership-model.md
+++ b/docs/adr/0003-use-explicit-membership-model.md
@@ -1,0 +1,63 @@
+# ADR 0003: Use Explicit Team Membership Instead of Generalized Role Bearers
+
+## Status
+
+Accepted for Sprint 0 foundation.
+
+## Context
+
+The archived SquadSync system experimented with a generalized role-bearing model. That direction allowed multiple entity types, such as users and organizational units, to participate in role assignment patterns.
+
+That abstraction has long-term theoretical value, but it increases complexity for the public MVP. It also begins to reveal broader platform ideas that are intentionally outside the public scope.
+
+The MVP needs a clear, soccer-specific model that supports roster management, team roles, and future authorization without premature generalization.
+
+## Decision
+
+The public MVP will model team participation through an explicit `TeamMembership` relationship.
+
+Core relationship:
+
+```text
+User -> TeamMembership -> Team
+TeamMembership -> Role
+```
+
+A user may have multiple memberships across teams. Each membership describes the user's relationship and role within that team.
+
+The public MVP will not use `IRoleBearer`, generic role-bearing interfaces, or broad organization-unit inheritance patterns.
+
+## Consequences
+
+### Benefits
+
+- Easier to understand and explain.
+- Better fit for the soccer-focused MVP.
+- Easier to authorize because permissions are team-contextual.
+- Avoids premature abstraction.
+- Keeps broader private platform design hidden.
+- Makes frontend workflows simpler.
+
+### Trade-offs
+
+- Less flexible than a generalized role-bearing model.
+- Future expansion to organizations, clubs, leagues, or competitions may require additional modeling.
+- Some archived code concepts will not be ported directly.
+
+## Alternatives Considered
+
+### Keep `IRoleBearer`
+
+Rejected for the public MVP. It is powerful but too abstract for the first rebuild and exposes too much of the broader platform direction.
+
+### Put Roles Directly on Users
+
+Rejected. User-level roles do not represent team-specific context well. A user may be a coach on one team and a player or viewer on another.
+
+### Use Only Player and Coach Tables Without Membership
+
+Rejected. That would be simple initially but would make multi-team participation and authorization harder later.
+
+## Review Trigger
+
+Revisit this ADR if SquadSync needs to model clubs, leagues, organizations, or nested team structures in the public repo.

--- a/docs/adr/0004-separate-soccer-subber-service.md
+++ b/docs/adr/0004-separate-soccer-subber-service.md
@@ -1,0 +1,72 @@
+# ADR 0004: Keep Soccer-Subber as a Separate Service
+
+## Status
+
+Accepted for Sprint 0 foundation.
+
+## Context
+
+SquadSync needs a path to demonstrate microservice integration, cloud/serverless readiness, and future lineup optimization behavior. The owner also wants to keep proprietary optimization details outside the public platform repository.
+
+A separate `soccer-subber` service can provide this boundary. SquadSync can define a public-safe request/response contract while the actual algorithm remains outside the core platform.
+
+## Decision
+
+The public SquadSync monorepo will not contain the proprietary lineup optimization implementation.
+
+Instead:
+
+- SquadSync will define a public-safe service boundary for lineup suggestions.
+- The separate `soccer-subber` service will eventually implement the optimization behavior.
+- Early SquadSync development may use a mock lineup suggestion adapter.
+- Future integration can use HTTP, events, or AWS service patterns depending on the deployment phase.
+
+## Consequences
+
+### Benefits
+
+- Protects private algorithm/IP details.
+- Demonstrates service-boundary thinking.
+- Creates a natural AWS/serverless learning path.
+- Keeps the core platform simpler.
+- Allows the optimization service to evolve independently.
+
+### Trade-offs
+
+- Adds integration complexity later.
+- Requires contract versioning discipline.
+- Local development may need mocks or service emulation.
+- More moving parts when deployed.
+
+## Public Contract Direction
+
+The public contract may include concepts such as:
+
+- Team identifier
+- Match identifier
+- Formation
+- Available players
+- Player preferred positions
+- Simple planning constraints
+- Suggested lineup assignments
+- Public-safe summary text
+
+The public contract should not include proprietary scoring methods, ranking formulas, or detailed optimization heuristics.
+
+## Alternatives Considered
+
+### Embed Optimization in SquadSync
+
+Rejected. This would simplify local development but would expose private logic and reduce the architecture value of a separate service boundary.
+
+### Keep Optimization Entirely Undocumented
+
+Rejected. The public platform should still show that it is designed for integration and cloud-native expansion.
+
+### Build Soccer-Subber First
+
+Rejected for now. The core platform needs enough roster/match/lineup data before the optimization service can be meaningfully integrated.
+
+## Review Trigger
+
+Revisit this ADR when the first integration contract is implemented or when the service deployment strategy is selected.

--- a/docs/prompt-library/backend-scaffold.prompt.md
+++ b/docs/prompt-library/backend-scaffold.prompt.md
@@ -1,0 +1,57 @@
+# Prompt: Backend Scaffold
+
+Use this prompt when asking an AI coding agent to create the initial backend skeleton.
+
+```text
+You are working in the SquadSync repository.
+
+Read first:
+- AGENTS.md
+- README.md
+- docs/planning/mvp-scope.md
+- docs/architecture/system-overview.md
+- docs/architecture/domain-model.md
+- docs/adr/0001-public-safe-scope.md
+- docs/adr/0002-use-aspnet-core.md
+- docs/adr/0003-use-explicit-membership-model.md
+- .github/instructions/backend.instructions.md
+
+Task:
+Create the initial ASP.NET Core backend scaffold under /backend.
+
+Required structure:
+/backend
+  /src
+    SquadSync.Api
+    SquadSync.Application
+    SquadSync.Domain
+    SquadSync.Infrastructure
+  /tests
+    SquadSync.UnitTests
+    SquadSync.IntegrationTests
+
+Requirements:
+- Create a .NET solution.
+- Add project references with proper dependency direction.
+- Add an API health endpoint at /health.
+- Add Swagger/OpenAPI for local development.
+- Add Serilog console logging.
+- Add basic appsettings files.
+- Add Docker Compose support for PostgreSQL if appropriate for the scaffold task.
+- Add a basic GitHub Actions workflow for restore/build/test if requested by the issue.
+
+Non-goals:
+- Do not implement domain entities yet.
+- Do not implement authentication yet.
+- Do not implement soccer-subber integration yet.
+- Do not expose proprietary algorithm details.
+- Do not introduce generalized competition-platform abstractions.
+
+Acceptance criteria:
+- Solution builds.
+- API starts locally.
+- /health returns healthy response.
+- Swagger is available in development.
+- Project dependency direction matches docs.
+- README or setup docs are updated if commands are added.
+```

--- a/docs/prompt-library/pr-review.prompt.md
+++ b/docs/prompt-library/pr-review.prompt.md
@@ -1,0 +1,34 @@
+# Prompt: PR Review
+
+Use this prompt when asking ChatGPT or another reviewer to inspect a pull request.
+
+```text
+You are reviewing a SquadSync pull request as an architect/technical lead.
+
+Read first:
+- AGENTS.md
+- README.md
+- docs/planning/mvp-scope.md
+- docs/architecture/system-overview.md
+- docs/architecture/domain-model.md
+- relevant ADRs
+
+Review goals:
+- Confirm the PR stays inside MVP scope.
+- Confirm architecture boundaries are respected.
+- Confirm no private IP or proprietary algorithm details are exposed.
+- Confirm naming is clear and soccer-specific.
+- Confirm tests/build/docs were updated where appropriate.
+- Identify unnecessary complexity or premature abstraction.
+- Identify missing follow-up issues.
+
+Output format:
+1. Summary
+2. Blocking issues
+3. Non-blocking improvements
+4. Architecture notes
+5. Test/validation notes
+6. Recommended merge decision
+
+Be direct and specific. Cite files and lines when available.
+```


### PR DESCRIPTION
## Summary

Completes the remaining Sprint 0 agent-foundation documentation package by adding:

- ADR 0003: explicit team membership model
- ADR 0004: separate soccer-subber service boundary
- Backend scaffold prompt template
- PR review prompt template

Earlier Sprint 0 documents have already been merged into `main`; this PR closes the remaining foundation gap.

## Why this matters

These files help keep the public SquadSync rebuild scoped, reviewable, and agent-ready before implementation begins. They define the domain modeling guardrail, the service-boundary strategy, and reusable prompts for future Codex/AI-assisted work.

## Validation

Documentation-only change. No application code or tests added.

## Review Focus

Please review for:

- Public-safe scope boundaries
- Accuracy of the membership-model decision
- Whether soccer-subber is described with enough integration signal without exposing private algorithm details
- Whether the prompt templates are specific enough for agent-assisted implementation