### PR TITLE
docs: refine agent prompt language

### DIFF
--- a/docs/agent-workflows/codex-task-lifecycle.md
+++ b/docs/agent-workflows/codex-task-lifecycle.md
@@ -6,7 +6,7 @@ Draft for Sprint 0 review.
 
 ## Purpose
 
-This document defines how AI-assisted implementation work should flow in SquadSync. The goal is to make Codex, Copilot, and ChatGPT useful without allowing them to create architectural drift or expose private IP.
+This document defines how AI-assisted implementation work should flow in SquadSync. The goal is to make Codex, Copilot, and ChatGPT useful while keeping changes small, reviewable, and aligned with the documented architecture.
 
 ## Workflow Summary
 
@@ -62,9 +62,9 @@ Every agent-ready task should include:
 Before implementation, verify:
 
 - task fits the MVP scope
-- task does not expose private IP
 - architecture is already documented or an ADR exists
 - task is small enough for one PR
+- service responsibilities are clear
 
 ### 3. Generate or Assign the Task
 
@@ -112,7 +112,7 @@ Review for:
 - readability
 - maintainability
 - test coverage
-- public-safety/IP risk
+- service-boundary clarity
 - hiring-facing clarity
 
 ### 8. Merge or Iterate
@@ -180,11 +180,11 @@ Symptom: new folders, libraries, or patterns appear without explanation.
 
 Prevention: require ADRs for architecture changes.
 
-### Public IP Leakage
+### Service Boundary Drift
 
-Symptom: docs or code describe hidden platform strategy or optimization details.
+Symptom: a task embeds behavior that belongs behind a separate integration boundary.
 
-Prevention: keep soccer-specific public MVP language and review docs carefully.
+Prevention: keep external service responsibilities behind documented ports/interfaces.
 
 ### Framework-Centered Code
 
@@ -207,5 +207,5 @@ A PR is mergeable when it is:
 - reasonably tested
 - readable
 - documented where needed
-- free of private IP leakage
+- clear about service responsibilities
 - understandable to a future reviewer

--- a/docs/prompt-library/backend-scaffold.prompt.md
+++ b/docs/prompt-library/backend-scaffold.prompt.md
@@ -11,7 +11,7 @@ Read first:
 - docs/planning/mvp-scope.md
 - docs/architecture/system-overview.md
 - docs/architecture/domain-model.md
-- docs/adr/0001-public-safe-scope.md
+- docs/adr/0001-initial-soccer-mvp-scope.md
 - docs/adr/0002-use-aspnet-core.md
 - docs/adr/0003-use-explicit-membership-model.md
 - .github/instructions/backend.instructions.md
@@ -44,8 +44,8 @@ Non-goals:
 - Do not implement domain entities yet.
 - Do not implement authentication yet.
 - Do not implement soccer-subber integration yet.
-- Do not expose proprietary algorithm details.
-- Do not introduce generalized competition-platform abstractions.
+- Do not implement lineup suggestion behavior yet.
+- Do not introduce broad product areas outside the MVP scope.
 
 Acceptance criteria:
 - Solution builds.

--- a/docs/prompt-library/pr-review.prompt.md
+++ b/docs/prompt-library/pr-review.prompt.md
@@ -16,7 +16,7 @@ Read first:
 Review goals:
 - Confirm the PR stays inside MVP scope.
 - Confirm architecture boundaries are respected.
-- Confirm no private IP or proprietary algorithm details are exposed.
+- Confirm service responsibilities remain clear.
 - Confirm naming is clear and soccer-specific.
 - Confirm tests/build/docs were updated where appropriate.
 - Identify unnecessary complexity or premature abstraction.


### PR DESCRIPTION
## Summary

Updates the remaining Sprint 0 agent workflow and prompt-library docs to match the revised product-scope language.

## Changes

- Refines Codex task lifecycle wording
- Updates the backend scaffold prompt ADR reference
- Refines backend scaffold non-goals
- Refines PR review goals

## Validation

Documentation-only change.