### PR TITLE
docs: add workflow templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture-decision.md
+++ b/.github/ISSUE_TEMPLATE/architecture-decision.md
@@ -1,0 +1,56 @@
+---
+name: Architecture decision or design task
+about: Propose or update an architectural decision for SquadSync
+title: ""
+labels: "architecture, docs"
+assignees: ""
+---
+
+## Objective
+
+Describe the architecture question, decision, or design update needed.
+
+## Context
+
+Explain the problem, constraints, and why this decision matters now.
+
+## Decision Needed
+
+State the decision to be made or the design direction to evaluate.
+
+## Options Considered
+
+### Option 1
+
+- Summary:
+- Benefits:
+- Trade-offs:
+
+### Option 2
+
+- Summary:
+- Benefits:
+- Trade-offs:
+
+## Recommendation
+
+State the recommended path and why.
+
+## Relevant Docs / ADRs
+
+- `docs/planning/project-roadmap.md`
+- `docs/planning/mvp-scope.md`
+- `docs/architecture/system-overview.md`
+- `docs/architecture/domain-model.md`
+- `docs/adr/`
+
+## Acceptance Criteria
+
+- [ ] Decision is documented
+- [ ] ADR is created or updated if needed
+- [ ] Follow-up implementation issues are identified if needed
+- [ ] Existing docs remain aligned
+
+## Suggested Follow-ups
+
+Optional. List workflow, documentation, architecture, validation, or follow-up issue suggestions discovered while completing this task. Leave blank if none.

--- a/.github/ISSUE_TEMPLATE/feature-task.md
+++ b/.github/ISSUE_TEMPLATE/feature-task.md
@@ -1,0 +1,63 @@
+---
+name: Feature or implementation task
+about: Define a scoped implementation task for SquadSync
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Objective
+
+Describe the specific outcome this issue should produce.
+
+## Context
+
+Explain why this task matters and how it fits the current phase, sprint, or roadmap item.
+
+## Scope
+
+List the files, folders, features, or behavior expected to change.
+
+## Non-Goals
+
+List what should not be changed in this task.
+
+## Relevant Docs / ADRs
+
+- `README.md`
+- `AGENTS.md`
+- `docs/planning/project-roadmap.md`
+- `docs/planning/mvp-scope.md`
+- `docs/architecture/system-overview.md`
+- `docs/architecture/domain-model.md`
+- `docs/adr/`
+
+Add or remove references as appropriate.
+
+## Acceptance Criteria
+
+- [ ] Clear criterion 1
+- [ ] Clear criterion 2
+- [ ] Clear criterion 3
+
+## Validation
+
+List commands, checks, or review steps required to validate the work.
+
+```bash
+# Example
+# dotnet build
+# dotnet test
+```
+
+## Documentation Impact
+
+- [ ] No documentation changes needed
+- [ ] README update needed
+- [ ] Architecture doc update needed
+- [ ] ADR needed or updated
+- [ ] Prompt/workflow doc update needed
+
+## Suggested Follow-ups
+
+Optional. List workflow, documentation, architecture, validation, or follow-up issue suggestions discovered while completing this task. Leave blank if none.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+## Summary
+
+Briefly describe what this PR changes and why.
+
+## Related Issue(s)
+
+Closes #
+
+## Scope
+
+List the main files, folders, features, or behavior changed.
+
+## Non-Goals
+
+List anything intentionally not included in this PR.
+
+## Validation
+
+Describe checks performed.
+
+```bash
+# Example
+# dotnet build
+# dotnet test
+```
+
+## Documentation Impact
+
+- [ ] No documentation changes needed
+- [ ] README updated
+- [ ] Architecture docs updated
+- [ ] ADR created or updated
+- [ ] Prompt/workflow docs updated
+
+## Architecture Notes
+
+Describe any architecture-relevant decisions, trade-offs, or service-boundary implications. Write `N/A` if none.
+
+## Suggested Follow-ups
+
+Optional. List workflow, documentation, architecture, validation, or follow-up issue suggestions discovered while completing this PR. Leave blank if none.
+
+## Review Checklist
+
+- [ ] PR stays inside issue scope
+- [ ] Relevant docs/ADRs were considered
+- [ ] Tests or validation steps are documented
+- [ ] Naming is clear and consistent
+- [ ] Follow-up work is captured if needed

--- a/docs/agent-workflows/branch-thread-workflow.md
+++ b/docs/agent-workflows/branch-thread-workflow.md
@@ -1,0 +1,102 @@
+# Branch Thread Workflow
+
+## Purpose
+
+Branch threads are focused ChatGPT discussions for a specific sprint, issue, PR, debugging task, or implementation review.
+
+A branch thread should execute scoped work, not redefine the roadmap. If the branch thread discovers broader work, it should surface that work as a suggested follow-up and return it to the main thread for prioritization.
+
+## Use Branch Threads For
+
+- implementing a specific GitHub Issue
+- reviewing a specific Pull Request
+- debugging a focused problem
+- generating a Codex prompt for one task
+- validating a sprint deliverable
+- producing a closeout summary
+
+## Standard Branch Thread Prompt
+
+```text
+We are working on SquadSync inside the ChatGPT Project “SqudSync.”
+
+Use the GitHub connector.
+
+Repository:
+https://github.com/bbubb/squadsync
+
+Current task:
+[Issue/PR/Sprint/Phase name and number]
+
+Goal:
+[One clear goal]
+
+Relevant docs:
+- README.md
+- AGENTS.md
+- docs/planning/project-roadmap.md
+- docs/planning/mvp-scope.md
+- docs/architecture/system-overview.md
+- docs/architecture/domain-model.md
+- docs/agent-workflows/codex-task-lifecycle.md
+- docs/adr/
+- .github/ISSUE_TEMPLATE/
+- .github/PULL_REQUEST_TEMPLATE.md
+
+Additional relevant docs for this task:
+[List task-specific docs/prompts]
+
+Non-goals:
+[List what should not be changed]
+
+Instructions:
+Review the relevant issue/PR/docs first. Confirm scope, non-goals, acceptance criteria, and validation steps before making or recommending changes. Keep the work focused on the current task. Surface suggested follow-ups separately instead of expanding scope.
+```
+
+## Branch Thread Operating Loop
+
+```text
+1. Inspect the referenced issue, PR, and docs.
+2. Confirm scope, non-goals, acceptance criteria, and validation.
+3. Execute or guide the scoped work.
+4. Create/update branch or PR when appropriate.
+5. Review results against acceptance criteria.
+6. Capture suggested follow-ups without expanding scope.
+7. Produce a closeout summary for the main thread.
+```
+
+## Closeout Summary Template
+
+```markdown
+## Sprint/Issue Completed
+
+Name/number:
+
+## What Changed
+
+- 
+
+## PRs / Branches
+
+- 
+
+## Validation
+
+- 
+
+## Docs / ADRs Updated
+
+- 
+
+## Follow-up Issues Created or Suggested
+
+- 
+
+## Questions for Main Planning
+
+- 
+```
+
+## Scope Rule
+
+If a branch thread uncovers work outside the current issue, do not silently implement it. Record it under suggested follow-ups and return it to the main thread.

--- a/docs/agent-workflows/main-thread-workflow.md
+++ b/docs/agent-workflows/main-thread-workflow.md
@@ -1,0 +1,120 @@
+# Main Thread Workflow
+
+## Purpose
+
+The main ChatGPT thread acts as the project control room for SquadSync. It should maintain overall project coherence, inspect the repository when needed, plan upcoming work, and decide when to branch into focused sprint or issue discussions.
+
+The main thread is not where detailed implementation work should happen. Implementation, debugging, and PR-specific review should usually happen in scoped branch threads.
+
+## Responsibilities
+
+Use the main thread for:
+
+- roadmap and phase decisions
+- sprint planning
+- deciding what issue should be worked next
+- creating or refining GitHub Issues
+- reviewing sprint closeout summaries
+- deciding whether follow-up issues or ADRs are needed
+- checking whether a phase is complete enough to proceed
+- keeping GitHub Issues, Projects, docs, and PRs aligned
+
+## Standard Main Thread Startup
+
+When starting a new main planning discussion, use a durable prompt that references the repository and stable docs, but does not hard-code current sprint state.
+
+The main thread should inspect repository docs and GitHub Issues/PRs to determine current state.
+
+## Main Thread Operating Loop
+
+```text
+1. Inspect repo/docs/issues/PRs as needed.
+2. Summarize current project state.
+3. Identify the next recommended phase/sprint/issue.
+4. Ask for human confirmation when the next step changes scope or starts a new sprint.
+5. Generate or update GitHub Issues as needed.
+6. Provide a focused branch-thread prompt for execution.
+7. After branch work completes, review the closeout summary.
+8. Update roadmap/issues/docs if needed.
+9. Repeat.
+```
+
+## Startup Response Pattern
+
+When the main thread starts or is asked to re-orient, respond with:
+
+```markdown
+## Current Project State
+
+- Current phase:
+- Current sprint:
+- Relevant open issues:
+- Relevant open PRs:
+- Recently completed work:
+
+## Recommended Next Step
+
+Recommended task:
+Reason:
+Relevant docs:
+Expected output:
+
+## Confirmation Needed
+
+Confirm whether to proceed with this next step. If confirmed, I will generate the sprint/issue plan and branch-thread prompt.
+```
+
+## Sprint Planning in the Main Thread
+
+Sprint planning belongs in the main thread.
+
+For each sprint, the main thread should define:
+
+- phase
+- sprint name
+- sprint goal
+- included issues
+- non-goals
+- relevant docs/ADRs
+- expected branch/thread prompts
+- acceptance criteria
+- validation expectations
+- project board field suggestions
+
+The main thread may create GitHub Issues directly when the scope is clear.
+
+## Branch Thread Handoff
+
+When a sprint or issue is ready for execution, the main thread should produce a branch-thread prompt that includes:
+
+- repository
+- current issue/PR/sprint
+- goal
+- relevant docs
+- non-goals
+- acceptance criteria
+- validation steps
+- instructions to inspect the issue/docs first
+
+## Sprint Closeout
+
+When a branch thread completes a sprint or issue, bring a closeout summary back to the main thread. The main thread should then decide whether to:
+
+- mark the issue complete
+- create follow-up issues
+- update docs or ADRs
+- adjust the roadmap
+- proceed to the next sprint
+
+## Human Checkpoints
+
+The human owner should be asked for confirmation before:
+
+- starting a new sprint
+- changing phase direction
+- adding a new architectural pattern
+- creating a large batch of issues
+- changing scope
+- merging work that has not been validated
+
+The human owner should not need to manually manage every implementation detail once the sprint and issue scope are approved.


### PR DESCRIPTION
## Summary

Adds GitHub issue/PR templates and ChatGPT workflow docs to support the SquadSync AI-assisted workflow.

Closes #12

## Changes

- Adds feature/implementation task issue template
- Adds architecture decision issue template
- Adds pull request template
- Adds main thread workflow guidance
- Adds branch thread workflow guidance
- Includes documentation impact and suggested follow-up sections

## Validation

Documentation/workflow-only change.

## Review Focus

Confirm the workflow supports:

- main-thread sprint planning
- branch-thread execution
- issue/PR template consistency
- human approval checkpoints
- suggested follow-ups without scope expansion