### PR TITLE
docs: clarify sprint-level branch workflow

### DIFF
--- a/docs/agent-workflows/branch-thread-workflow.md
+++ b/docs/agent-workflows/branch-thread-workflow.md
@@ -4,11 +4,28 @@
 
 Branch threads are focused ChatGPT discussions for a specific sprint, issue, PR, debugging task, or implementation review.
 
+Prefer one branch thread per sprint. Use issue-level branch threads only when a task becomes complex, blocked, or requires isolated review/debugging.
+
 A branch thread should execute scoped work, not redefine the roadmap. If the branch thread discovers broader work, it should surface that work as a suggested follow-up and return it to the main thread for prioritization.
+
+## Workflow Mental Model
+
+```text
+Main thread = project control room
+Sprint branch thread = sprint execution manager
+Issue/PR subthreads = optional escalation path
+Codex = implementation worker
+GitHub Copilot = local coding assistant
+GitHub Issues = task records
+GitHub Project = visual tracking board
+Docs/ADRs = durable project memory
+```
 
 ## Use Branch Threads For
 
-- implementing a specific GitHub Issue
+- managing execution across a confirmed sprint
+- working through sprint issues in sequence
+- implementing a specific GitHub Issue when isolated focus is needed
 - reviewing a specific Pull Request
 - debugging a focused problem
 - generating a Codex prompt for one task
@@ -56,13 +73,14 @@ Review the relevant issue/PR/docs first. Confirm scope, non-goals, acceptance cr
 ## Branch Thread Operating Loop
 
 ```text
-1. Inspect the referenced issue, PR, and docs.
+1. Inspect the referenced sprint, issue, PR, and docs.
 2. Confirm scope, non-goals, acceptance criteria, and validation.
 3. Execute or guide the scoped work.
 4. Create/update branch or PR when appropriate.
 5. Review results against acceptance criteria.
 6. Capture suggested follow-ups without expanding scope.
-7. Produce a closeout summary for the main thread.
+7. Move to the next sprint issue when appropriate.
+8. Produce a closeout summary for the main thread when the sprint or issue is complete.
 ```
 
 ## Closeout Summary Template
@@ -99,4 +117,4 @@ Name/number:
 
 ## Scope Rule
 
-If a branch thread uncovers work outside the current issue, do not silently implement it. Record it under suggested follow-ups and return it to the main thread.
+If a branch thread uncovers work outside the current sprint or issue, do not silently implement it. Record it under suggested follow-ups and return it to the main thread.

--- a/docs/agent-workflows/main-thread-workflow.md
+++ b/docs/agent-workflows/main-thread-workflow.md
@@ -124,6 +124,8 @@ When a sprint or issue is ready for execution, the main thread should produce a 
 
 A branch-thread handoff should happen only after the sprint/issue scope is confirmed.
 
+By default, generate a sprint-level branch-thread prompt. Generate an issue-level branch-thread prompt only when the task needs isolated execution, review, or debugging.
+
 ## Sprint Closeout
 
 When a branch thread completes a sprint or issue, bring a closeout summary back to the main thread. The main thread should then decide whether to:


### PR DESCRIPTION
## Summary

Clarifies that branch discussions should default to sprint-level execution, with issue/PR subthreads used only when isolated review, debugging, or complexity requires it.

## Changes

- Adds workflow mental model to branch-thread workflow
- States that one branch thread per sprint is preferred
- Updates branch thread use cases and loop for sprint issue sequencing
- Adds main-thread guidance that default handoff should be sprint-level

## Validation

Documentation-only change.