### PR TITLE
docs: polish root README and project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,136 @@
 # SquadSync
 
-SquadSync is a soccer team management and match-planning platform for coaches. The project demonstrates production-minded full-stack architecture using ASP.NET Core, a modern React/Next.js frontend, relational persistence, and planned integration points for lineup assistance and event-driven notifications.
+SquadSync is a soccer-focused team management and match-planning platform for coaches. The MVP demonstrates production-minded full-stack architecture, clean service boundaries, and an AI-assisted engineering workflow around a focused soccer use case.
 
-## Current Status
+The project is intentionally scoped to a practical vertical slice: team and roster management, match planning, manual lineup construction, and future integration points for lineup assistance and event-driven notifications.
 
-Phase 0 establishes the project foundation: architecture docs, agentic workflow guidance, architectural decision records, and repository instructions for AI-assisted development.
+## Current State
 
-Application code will be added after the foundation documents and Codex CLI operational workflow are reviewed and accepted.
+SquadSync is in active MVP development.
 
-## Product Scope
+Phase 0 established architecture, planning, and agentic workflow standards. Phase 1 begins the backend foundation for the API.
 
-The MVP focuses on:
+Canonical planning state and active work are tracked in:
 
-- Team creation and roster management
-- Player and coach profiles
-- Team membership and role assignment
-- Match planning
-- Manual lineup construction
-- A future integration contract for a separate `soccer-subber` lineup assistance service
-- A future AWS event-notification path for lineup and roster events
+- [Project Roadmap](docs/planning/project-roadmap.md)
+- [GitHub Issues](https://github.com/bbubb/squadsync/issues)
+- GitHub Project board
 
-## Proposed Architecture
+## Tech Stack
+
+| Layer | Technology | Notes |
+|---|---|---|
+| API | ASP.NET Core Web API | Planned under `apps/api/` |
+| API language | C# | Modular monolith / Clean Architecture style |
+| Database | PostgreSQL | Local first, cloud-ready later |
+| ORM | Entity Framework Core | Planned persistence layer |
+| Validation | FluentValidation | Planned request/use-case validation |
+| Logging | Serilog | Planned structured logging |
+| API docs | Swagger / OpenAPI | Development API inspection |
+| Web | Next.js + TypeScript | Planned under `apps/web/` |
+| Styling | Tailwind CSS | Planned frontend styling baseline |
+| Server state | TanStack Query | Planned API data access pattern |
+| Local environment | Docker Compose | Local PostgreSQL and supporting services |
+| Testing | xUnit / integration tests | TDD-oriented implementation workflow |
+| CI | GitHub Actions | Restore/build/test once application scaffold exists |
+| Cloud direction | AWS serverless where practical | Scale-to-zero preference for event-driven capabilities |
+
+## Repo Layout
 
 ```text
-frontend/      Next.js + TypeScript dashboard
-backend/       ASP.NET Core modular monolith
-infra/         Local Docker and future AWS infrastructure artifacts
-docs/          Architecture, planning, ADRs, diagrams, and agentic workflow docs
-.github/       CI, issue templates, and AI coding assistant instructions
+apps/                 # Application surfaces
+  api/                #   ASP.NET Core API / modular monolith
+  web/                #   Next.js frontend
+infra/                # Local and future cloud infrastructure notes/artifacts
+  docker/             #   Local Docker Compose direction
+  aws/                #   Future AWS/serverless direction
+docs/                 # Architecture, planning, ADRs, integrations, diagrams, workflow docs
+  architecture/       #   System and domain architecture
+  planning/           #   Roadmap, MVP scope, implementation planning
+  adr/                #   Architecture decision records
+  integrations/       #   External service boundaries such as soccer-subber
+  agentic-workflow/   #   AI-assisted workflow, tool profiles, rules, skills, hooks
+.github/              # Issue templates, PR template, and future CI workflows
 ```
 
-The core platform will be built as a modular monorepo. Integrated services such as `soccer-subber` and AWS-based notifications are treated as separate deployable capabilities to demonstrate service boundaries, cloud integration, and scalable design.
+## Architecture
 
-## Planned Technical Stack
-
-- Backend: C# / ASP.NET Core Web API
-- Application architecture: modular monolith with Domain, Application, Infrastructure, and API boundaries
-- Database: PostgreSQL
-- ORM: Entity Framework Core
-- Validation: FluentValidation
-- Logging: Serilog
-- API documentation: Swagger/OpenAPI
-- Frontend: Next.js, TypeScript, Tailwind CSS, TanStack Query
-- Local environment: Docker Compose
-- Testing: xUnit, integration tests, and later architecture/dependency tests
-- Cloud direction: AWS-aligned eventing, deployment, and service integration
-
-## Documentation Map
+SquadSync is designed as a modular monorepo. The core API starts as a modular monolith with clear Domain, Application, Infrastructure, and API boundaries. External capabilities such as `soccer-subber` lineup assistance and AWS-based notifications are integrated through explicit contracts/ports instead of being embedded directly into the core platform.
 
 Start here:
 
-- [MVP Scope](docs/planning/mvp-scope.md)
 - [System Overview](docs/architecture/system-overview.md)
 - [Domain Model](docs/architecture/domain-model.md)
-- [Agentic Workflow Architecture](docs/agentic-workflow/README.md)
-- [Codex CLI Tool Profile](docs/agentic-workflow/tools/codex-cli/README.md)
 - [Architectural Decisions](docs/adr/)
+- [Soccer-Subber Integration](docs/integrations/soccer-subber/README.md)
 
-AI coding agents and assistants should read [AGENTS.md](AGENTS.md) before modifying the repository.
+## Agentic Workflow
 
-## Development Philosophy
+SquadSync uses repository-owned planning, workflow, and tool-profile documents so AI-assisted development remains reviewable and durable. GitHub issues define executable work, pull requests provide review gates, and human review owns merge decisions.
 
-This project prioritizes:
+Start here:
 
-- Clear architecture over clever abstractions
-- Explicit domain relationships over premature generalization
-- Small, reviewable changes
-- Documentation-backed decisions
-- AI-assisted development with human review gates
-- A working vertical slice before broad feature expansion
+- [AGENTS.md](AGENTS.md)
+- [Agentic Workflow Architecture](docs/agentic-workflow/README.md)
+- [ChatGPT GitHub Tool Profile](docs/agentic-workflow/tools/chatgpt-github/README.md)
+- [Codex CLI Tool Profile](docs/agentic-workflow/tools/codex-cli/README.md)
+- [Branching Strategy](docs/agentic-workflow/workflow/branching-strategy.md)
+- [Testing Strategy](docs/agentic-workflow/workflow/testing-strategy.md)
+- [Coding Standards](docs/agentic-workflow/workflow/coding-standards.md)
 
-## Scope Rule
+## Getting Started
 
-Keep implementation aligned with the documented soccer MVP. New product areas, architectural patterns, or service responsibilities should be introduced through an issue and, when architectural, an ADR.
+Application code has not been scaffolded yet. Phase 1 will create the API foundation under `apps/api/` with build and test validation.
+
+Until then, begin with the documentation map below and the active GitHub issue/PR workflow.
+
+## Contributing
+
+This project uses trunk-based GitHub Flow:
+
+- create short-lived branches from `main`
+- link work to GitHub issues
+- keep pull requests small and reviewable
+- run or document validation before review
+- do not merge without human approval
+
+See:
+
+- [Branching Strategy](docs/agentic-workflow/workflow/branching-strategy.md)
+- [Pull Request Specification](docs/agentic-workflow/specs/pull-request-spec.md)
+- [Validation Gates](docs/agentic-workflow/workflow/validation-gates.md)
+
+## Links
+
+### Planning
+
+- [Project Roadmap](docs/planning/project-roadmap.md)
+- [MVP Scope](docs/planning/mvp-scope.md)
+
+### Architecture
+
+- [System Overview](docs/architecture/system-overview.md)
+- [Domain Model](docs/architecture/domain-model.md)
+- [Architectural Decisions](docs/adr/)
+- [Diagrams](docs/diagrams/README.md)
+
+### Integrations and Infrastructure
+
+- [Soccer-Subber Integration](docs/integrations/soccer-subber/README.md)
+- [Infrastructure](infra/README.md)
+- [Docker Direction](infra/docker/README.md)
+- [AWS Direction](infra/aws/README.md)
+
+### Agentic Workflow
+
+- [Agentic Workflow Architecture](docs/agentic-workflow/README.md)
+- [ChatGPT GitHub Tool Profile](docs/agentic-workflow/tools/chatgpt-github/README.md)
+- [Codex CLI Tool Profile](docs/agentic-workflow/tools/codex-cli/README.md)
+- [Codex Rules](docs/agentic-workflow/tools/codex-cli/rules/README.md)
+- [Codex Skills](docs/agentic-workflow/tools/codex-cli/skills/README.md)
+- [Codex Hooks](docs/agentic-workflow/tools/codex-cli/hooks/README.md)
+- [Codex Subagents](docs/agentic-workflow/tools/codex-cli/subagents/README.md)
+
+## License
+
+No license has been selected yet.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,23 @@
+# Apps
+
+This directory contains deployable application surfaces for SquadSync.
+
+## Planned Structure
+
+```text
+apps/
+  api/  ASP.NET Core API and modular monolith backend
+  web/  Next.js frontend application
+```
+
+## Current Status
+
+No application source code has been scaffolded yet.
+
+Phase 1 begins with the API foundation under `apps/api/`.
+
+## Rules
+
+- Keep application code under the appropriate app boundary.
+- Do not place infrastructure or planning documents here.
+- Use issue-backed PRs for app scaffolding and implementation.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,41 @@
+# SquadSync API
+
+The API app will contain the ASP.NET Core backend for SquadSync.
+
+## Planned Role
+
+`apps/api/` will host the modular monolith backend with clear boundaries:
+
+```text
+src/
+  SquadSync.Api/
+  SquadSync.Application/
+  SquadSync.Domain/
+  SquadSync.Infrastructure/
+tests/
+  SquadSync.UnitTests/
+  SquadSync.IntegrationTests/
+```
+
+## Current Status
+
+Not scaffolded yet.
+
+Phase 1 will create the initial .NET solution, projects, health endpoint, Swagger/OpenAPI setup, logging baseline, and test projects.
+
+## Validation Direction
+
+Once scaffolded, expected validation is:
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```
+
+## References
+
+- [System Overview](../../docs/architecture/system-overview.md)
+- [Domain Model](../../docs/architecture/domain-model.md)
+- [Testing Strategy](../../docs/agentic-workflow/workflow/testing-strategy.md)
+- [Coding Standards](../../docs/agentic-workflow/workflow/coding-standards.md)

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,28 @@
+# SquadSync Web
+
+The web app will contain the SquadSync frontend.
+
+## Planned Role
+
+`apps/web/` will host the future Next.js + TypeScript dashboard for coaches.
+
+Planned feature areas include:
+
+- teams
+- roster management
+- players
+- matches
+- lineups
+- soccer-subber integration status/results later
+
+## Current Status
+
+Not scaffolded yet.
+
+The frontend will be added after the backend foundation and core API direction are established.
+
+## References
+
+- [System Overview](../../docs/architecture/system-overview.md)
+- [MVP Scope](../../docs/planning/mvp-scope.md)
+- [Coding Standards](../../docs/agentic-workflow/workflow/coding-standards.md)

--- a/docs/agentic-workflow/tools/codex-cli/skills/scaffold-backend.md
+++ b/docs/agentic-workflow/tools/codex-cli/skills/scaffold-backend.md
@@ -1,12 +1,12 @@
-# Skill: Scaffold Backend
+# Skill: Scaffold API
 
 ## Purpose
 
-Use this skill for the Phase 1 backend scaffold task.
+Use this skill for the Phase 1 API scaffold task.
 
 ## Expected Outcome
 
-Create a minimal ASP.NET Core backend foundation that supports future domain, application, infrastructure, API, and test work.
+Create a minimal ASP.NET Core API foundation under `apps/api/` that supports future domain, application, infrastructure, API, and test work.
 
 ## Required Context
 
@@ -19,14 +19,15 @@ Before work begins, read:
 - `docs/architecture/domain-model.md`
 - `docs/agentic-workflow/workflow/testing-strategy.md`
 - `docs/agentic-workflow/workflow/coding-standards.md`
+- `apps/api/README.md`
 - Codex rules under `rules/`
 
 ## Expected Shape
 
-The backend scaffold should follow the planned modular structure:
+The API scaffold should follow the planned modular structure:
 
 ```text
-backend/
+apps/api/
   src/
     SquadSync.Api/
     SquadSync.Application/

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -10,14 +10,14 @@ This document describes the intended architecture for SquadSync. It gives future
 
 ## Architecture Summary
 
-SquadSync will be built as a modular monorepo containing a backend API, frontend dashboard, infrastructure artifacts, and project documentation.
+SquadSync will be built as a modular monorepo containing an API app, web app, infrastructure artifacts, and project documentation.
 
 The core platform is a modular monolith. External capabilities, such as lineup suggestions and cloud notifications, are integrated through explicit service boundaries rather than embedded directly into the platform core.
 
 ```mermaid
 flowchart LR
-    Coach[Coach / Team Manager] --> Frontend[Next.js Frontend]
-    Frontend --> Api[ASP.NET Core API]
+    Coach[Coach / Team Manager] --> Web[Next.js Web App]
+    Web --> Api[ASP.NET Core API]
     Api --> App[Application Layer]
     App --> Domain[Domain Layer]
     App --> Infra[Infrastructure Layer]
@@ -34,23 +34,24 @@ Planned layout:
 
 ```text
 squadsync/
-  backend/
-    src/
-      SquadSync.Api/
-      SquadSync.Application/
-      SquadSync.Domain/
-      SquadSync.Infrastructure/
-    tests/
-      SquadSync.UnitTests/
-      SquadSync.IntegrationTests/
-  frontend/
-    src/
-      app/
-      components/
-      features/
-      lib/
-      services/
-      types/
+  apps/
+    api/
+      src/
+        SquadSync.Api/
+        SquadSync.Application/
+        SquadSync.Domain/
+        SquadSync.Infrastructure/
+      tests/
+        SquadSync.UnitTests/
+        SquadSync.IntegrationTests/
+    web/
+      src/
+        app/
+        components/
+        features/
+        lib/
+        services/
+        types/
   infra/
     docker/
     aws/
@@ -59,15 +60,16 @@ squadsync/
     planning/
     adr/
     diagrams/
+    integrations/
     agentic-workflow/
   .github/
     workflows/
     ISSUE_TEMPLATE/
 ```
 
-## Backend Architecture
+## API Architecture
 
-The backend should use a modular ASP.NET Core structure with clear dependency direction.
+The API app should use a modular ASP.NET Core structure with clear dependency direction.
 
 ```mermaid
 flowchart TD
@@ -128,9 +130,9 @@ Responsibilities:
 
 Infrastructure implements interfaces defined by the application layer.
 
-## Frontend Architecture
+## Web Architecture
 
-The frontend should be a Next.js + TypeScript application organized by feature.
+The web app should be a Next.js + TypeScript application organized by feature.
 
 Primary feature areas:
 
@@ -180,6 +182,8 @@ The SquadSync repository may contain:
 - Failure handling rules
 - Planning summary placeholder
 
+The actual optimization service remains outside this repository unless a future ADR changes that boundary.
+
 ### Event Notification Boundary
 
 The core platform should eventually emit domain/application events. A later AWS notification capability can subscribe to or process these events.
@@ -201,7 +205,7 @@ Early local development should support:
 
 - Docker Compose for PostgreSQL
 - API running locally
-- Frontend running locally
+- Web app running locally
 - Swagger available for backend testing
 - Seed data for demo workflows
 
@@ -211,13 +215,15 @@ AWS integration should be layered in after the core vertical slice is useful.
 
 Potential path:
 
-1. Containerize backend
-2. Host database or use managed database
-3. Deploy frontend
+1. Containerize local development/runtime pieces where useful
+2. Host database or use managed database when justified
+3. Deploy web app
 4. Add event outbox pattern
 5. Add AWS notification pipeline
-6. Integrate soccer-subber as a serverless/containerized service
+6. Integrate soccer-subber through a service boundary
 7. Add AI-generated planning summary capability
+
+Scale-to-zero or low-idle-cost AWS services should be preferred where practical, especially for event-driven capabilities.
 
 ## Architectural Principle
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,21 @@
+# Diagrams
+
+This directory is reserved for architecture and workflow diagrams.
+
+## Current Status
+
+Placeholder only.
+
+Mermaid diagrams may live inline in architecture docs when that is easier to maintain. Larger diagrams or exported assets can be added here when useful.
+
+## Planned Uses
+
+- system context diagrams
+- deployment diagrams
+- domain relationship diagrams
+- event flow diagrams
+- agentic workflow diagrams
+
+## Rule
+
+Keep diagrams aligned with the canonical architecture docs. If a diagram conflicts with text documentation, pause and reconcile the source docs before updating the diagram.

--- a/docs/integrations/soccer-subber/README.md
+++ b/docs/integrations/soccer-subber/README.md
@@ -1,0 +1,32 @@
+# Soccer-Subber Integration
+
+This directory documents the planned integration boundary between SquadSync and the separate `soccer-subber` service.
+
+## Current Status
+
+`soccer-subber` remains a separate service/repository.
+
+SquadSync should not embed the substitution optimization algorithm inside the core platform. Instead, SquadSync should define a clean integration boundary.
+
+## Planned SquadSync Responsibilities
+
+SquadSync may contain:
+
+- lineup suggestion request/response contracts
+- application ports/interfaces
+- mock adapters for local/demo behavior
+- HTTP or event adapter later
+- failure handling and fallback behavior
+- documentation for integration assumptions
+
+## Non-Goals
+
+- Do not duplicate `soccer-subber` source code in this repository.
+- Do not implement optimization logic in the SquadSync core platform.
+- Do not require the external service for the early manual lineup MVP.
+
+## References
+
+- [System Overview](../../architecture/system-overview.md)
+- [MVP Scope](../../planning/mvp-scope.md)
+- [Project Roadmap](../../planning/project-roadmap.md)

--- a/docs/planning/project-roadmap.md
+++ b/docs/planning/project-roadmap.md
@@ -59,6 +59,7 @@ Phase 0 is not complete until the repository contains both:
 - Agent-ready issue template
 - Pull request review template
 - Project roadmap
+- Placeholder project areas for `apps/api`, `apps/web`, `infra`, and integrations
 
 ### Operational Harness Outcomes
 
@@ -74,6 +75,7 @@ The current Phase 0 hardening work adds:
 - agent-ready issue template
 - PR template alignment
 - future harness friction log
+- professional root README and project-area pathing
 
 ### Completion Criteria
 
@@ -88,17 +90,18 @@ The current Phase 0 hardening work adds:
 - Codex CLI has stable rules, skills, hooks, and subagent placeholder structure.
 - Branching, testing, coding, validation, and stop-condition standards are documented.
 - Tool-specific behavior is nested under `docs/agentic-workflow/tools/`.
+- App pathing is stabilized around `apps/api` and `apps/web`.
 - Phase 1 can begin without relying on hidden ChatGPT session context.
 
-## Phase 1: Backend Foundation
+## Phase 1: API Foundation
 
 ### Goal
 
-Create the backend solution scaffold and local development baseline.
+Create the API solution scaffold and local development baseline.
 
 ### Primary Outcomes
 
-- ASP.NET Core solution under `backend/`
+- ASP.NET Core solution under `apps/api/`
 - Modular projects: API, Application, Domain, Infrastructure
 - Unit and integration test projects
 - Health endpoint
@@ -110,13 +113,13 @@ Create the backend solution scaffold and local development baseline.
 
 ### Example Sprints
 
-- Sprint 1: backend scaffold
+- Sprint 1: API scaffold
 - Sprint 2: local database and infrastructure baseline
 - Sprint 3: CI/build/test hardening
 
 ### Completion Criteria
 
-- Backend builds locally.
+- API builds locally.
 - Health endpoint works.
 - Swagger is available in development.
 - Project references enforce intended dependency direction.
@@ -159,7 +162,7 @@ Implement the MVP domain model and persistence layer.
 
 ### Goal
 
-Expose usable backend behavior for team and roster management.
+Expose usable API behavior for team and roster management.
 
 ### Primary Outcomes
 
@@ -184,15 +187,15 @@ Expose usable backend behavior for team and roster management.
 - Player profile data can be created and updated.
 - API behavior is validated by tests.
 
-## Phase 4: Frontend Foundation
+## Phase 4: Web Foundation
 
 ### Goal
 
-Create the frontend application shell and connect it to backend APIs.
+Create the web application shell and connect it to APIs.
 
 ### Primary Outcomes
 
-- Next.js + TypeScript app under `frontend/`
+- Next.js + TypeScript app under `apps/web/`
 - Feature-oriented structure
 - Tailwind setup
 - API service layer
@@ -202,14 +205,14 @@ Create the frontend application shell and connect it to backend APIs.
 
 ### Example Sprints
 
-- Sprint 10: frontend scaffold and app shell
+- Sprint 10: web scaffold and app shell
 - Sprint 11: team dashboard
 - Sprint 12: roster management UI
 
 ### Completion Criteria
 
-- Frontend runs locally.
-- Frontend can call backend APIs.
+- Web app runs locally.
+- Web app can call backend APIs.
 - A reviewer can navigate the basic team/roster workflow.
 
 ## Phase 5: Match and Manual Lineup Planning
@@ -238,7 +241,7 @@ Implement the first soccer-specific planning workflow.
 - A coach can create a match.
 - A coach can track availability.
 - A coach can build and save a manual lineup.
-- The workflow is visible in the frontend.
+- The workflow is visible in the web app.
 
 ## Phase 6: Soccer-Subber Integration Boundary
 
@@ -303,8 +306,8 @@ Deploy a credible cloud-ready version and improve portfolio presentation.
 
 ### Primary Outcomes
 
-- Containerized backend
-- Hosted frontend
+- Containerized API if appropriate
+- Hosted web app
 - Managed or hosted database path
 - Deployment documentation
 - CI/CD improvements
@@ -315,7 +318,7 @@ Deploy a credible cloud-ready version and improve portfolio presentation.
 ### Example Sprints
 
 - Sprint 22: containerization and deployment prep
-- Sprint 23: cloud-hosted backend/frontend
+- Sprint 23: cloud-hosted API/web
 - Sprint 24: portfolio demo polish
 
 ### Completion Criteria
@@ -365,7 +368,7 @@ Each sprint should avoid:
 
 - broad product expansion
 - unapproved architecture changes
-- mixing backend, frontend, infra, and cloud work unless the sprint is explicitly integration-focused
+- mixing API, web, infra, and cloud work unless the sprint is explicitly integration-focused
 - implementation without a reviewable branch/PR
 
 ## Branched Conversation Strategy
@@ -402,6 +405,6 @@ This keeps each branch focused while preserving context from the main planning t
 
 ## Current Next Step
 
-Complete Phase 0 operational harness hardening.
+Complete Phase 0 documentation polish and project-area pathing.
 
-Phase 1 begins only after the agentic workflow architecture, engineering workflow standards, and ChatGPT GitHub/Codex CLI operational profiles are merged.
+Phase 1 begins with the API foundation under `apps/api/`.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,30 @@
+# Infrastructure
+
+This directory contains local infrastructure direction and future cloud deployment artifacts for SquadSync.
+
+## Current Status
+
+No runtime infrastructure code has been added yet.
+
+Phase 1 should prioritize local development support. Cloud deployment artifacts should be added later when the core vertical slice is useful.
+
+## Structure
+
+```text
+infra/
+  docker/  Local Docker and Docker Compose direction
+  aws/     Future AWS/serverless direction
+```
+
+## Direction
+
+- Use Docker/Docker Compose for local dependencies such as PostgreSQL.
+- Prefer AWS serverless or scale-to-zero services where practical for future MVP deployment.
+- Defer Terraform, CDK, SAM, and Kubernetes decisions until the deployment target is clearer.
+
+## Non-Goals
+
+- No Terraform modules yet.
+- No Kubernetes manifests yet.
+- No AWS deployment templates yet.
+- No production environment configuration yet.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -1,0 +1,33 @@
+# AWS Infrastructure
+
+This directory is reserved for future AWS deployment and integration artifacts.
+
+## Direction
+
+SquadSync should prefer scale-to-zero or low-idle-cost AWS services where practical, especially for event-driven capabilities such as notifications and future soccer-subber integration.
+
+Potential future candidates:
+
+- AWS Lambda for event-driven/serverless workloads
+- Amazon EventBridge for event routing
+- Amazon SNS/SES for notifications, if needed
+- Amazon RDS or Aurora Serverless for relational persistence, if justified
+- AWS SAM or CDK for serverless infrastructure, if the project outgrows manual setup
+
+## Current Status
+
+Placeholder only. No AWS deployment artifacts have been selected or added yet.
+
+## Deferred Decisions
+
+- Terraform vs CDK vs SAM
+- Container hosting vs serverless hosting
+- Managed database choice
+- Production network/security architecture
+- CI/CD handoff from GitHub Actions to AWS-native tooling
+
+## Non-Goals
+
+- Do not introduce Kubernetes for the MVP without a specific ADR.
+- Do not add Terraform-style `modules/` or `bootstrap/` structure until Terraform is selected.
+- Do not add AWS deployment code before the core application is useful locally.

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,0 +1,25 @@
+# Docker Infrastructure
+
+This directory is reserved for local Docker and Docker Compose artifacts.
+
+## Planned Role
+
+Phase 1 may add Docker Compose support for local dependencies such as PostgreSQL.
+
+Potential future files:
+
+```text
+infra/docker/
+  docker-compose.yml
+  README.md
+```
+
+## Current Status
+
+Placeholder only. No Docker runtime files have been added yet.
+
+## Rules
+
+- Keep local-only Docker artifacts here.
+- Do not place production cloud infrastructure here.
+- Document required environment variables when Docker Compose is introduced.


### PR DESCRIPTION
## Summary

Applies final Phase 0 documentation polish inspired by OmniWatcher’s professional Phase 0 structure, adapted to SquadSync’s smaller MVP/PoC scope.

This PR makes the root README a concise project landing page and stabilizes planned project pathing around:

```text
apps/api
apps/web
infra/docker
infra/aws
docs/integrations/soccer-subber
```

## Related Issue(s)

Closes #30

## Scope

Updates:

- `README.md`
- `docs/architecture/system-overview.md`
- `docs/planning/project-roadmap.md`
- `docs/agentic-workflow/tools/codex-cli/skills/scaffold-backend.md`

Adds placeholder/project-area docs:

- `apps/README.md`
- `apps/api/README.md`
- `apps/web/README.md`
- `infra/README.md`
- `infra/docker/README.md`
- `infra/aws/README.md`
- `docs/integrations/soccer-subber/README.md`
- `docs/diagrams/README.md`

## Non-Goals

- No application code.
- No .NET solution or project scaffold.
- No frontend scaffold.
- No Terraform, Kubernetes, AWS SAM, CDK, or deployment code.
- No product scope changes.
- No copy of OmniWatcher-specific Azure/Terraform architecture.

## Acceptance Criteria Status

- [x] Root README uses a concise professional landing-page structure.
- [x] Root README has a brief Current State section and points to canonical roadmap/issues/project board for detailed status.
- [x] Root README tech stack is represented as a clean table.
- [x] Root README has organized Links/navigation.
- [x] Planned repo layout uses `apps/api` and `apps/web` instead of `backend` and `frontend`.
- [x] System overview and roadmap align with the `apps/` structure.
- [x] Codex API scaffold skill targets `apps/api`.
- [x] Placeholder README files exist for app/infra/integration areas without adding source code.
- [x] Infra direction remains Docker-local and AWS/serverless-first; Terraform/Kubernetes are deferred.

## Validation

Docs-only validation performed:

- Verified changes are documentation/placeholders only.
- Verified no application source code was added.
- Verified root README links target files added or existing in this PR.
- Verified `system-overview.md`, roadmap, and Codex scaffold skill all target `apps/api` and `apps/web`.
- Verified infra placeholders defer Terraform, Kubernetes, SAM, CDK, and deployment decisions.

Commands run:

```bash
# Not run: documentation-only change; no application scaffold required.
```

## Documentation Impact

- [ ] No documentation changes needed
- [x] README updated
- [x] Architecture docs updated
- [ ] ADR created or updated
- [x] Prompt/workflow docs updated

## Architecture Notes

This PR changes repository pathing/documentation architecture only. The application architecture remains the same: API as modular monolith, web frontend, explicit soccer-subber integration boundary, and AWS/serverless direction deferred until the local vertical slice is useful.

## Agentic Workflow Notes

- [x] Relevant workflow docs/specs were considered
- [x] Validation gates were run or limitations documented
- [x] Stop conditions were considered
- [x] ADR need was considered

## Suggested Follow-ups

- Phase 1 should create the actual API scaffold under `apps/api/`.
- CI should be added under `.github/workflows/` once application scaffold exists.
- AWS deployment/IaC decisions should be captured later through ADRs when the deployment target is clearer.

## Review Checklist

- [x] PR stays inside issue scope
- [x] Relevant docs/ADRs were considered
- [x] Tests or validation steps are documented
- [x] Naming is clear and consistent
- [x] Follow-up work is captured if needed