### PR TITLE
docs: align native Codex plans and skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,28 @@
+# Native Agent Assets
+
+This directory contains repo-native agent assets intended for tools that discover project instructions from conventional paths.
+
+## Structure
+
+```text
+.agents/
+  skills/
+    squadsync-api-task/
+    squadsync-docs-maintenance/
+    squadsync-pr-review/
+    squadsync-spec-verification/
+```
+
+## Purpose
+
+The files under `.agents/skills/` are concise Codex-native skills.
+
+Expanded human-readable playbooks remain under:
+
+```text
+docs/agentic-workflow/tools/codex-cli/skills/
+```
+
+## Rule
+
+Keep native skills short and operational. Put deeper explanation in the documentation playbooks and link to them from each skill.

--- a/.agents/skills/squadsync-api-task/SKILL.md
+++ b/.agents/skills/squadsync-api-task/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: squadsync-api-task
+description: Use for SquadSync API/backend implementation tasks under apps/api, including scaffold work, domain/application/API changes, tests, and validation.
+---
+
+# SquadSync API Task
+
+Use this skill for scoped API/backend work in `apps/api/`.
+
+## Required Context
+
+Read first:
+
+- `AGENTS.md`
+- `PLANS.md` if the task is complex or multi-step
+- `apps/api/README.md`
+- `docs/architecture/system-overview.md`
+- `docs/architecture/domain-model.md`
+- `docs/agentic-workflow/workflow/coding-standards.md`
+- `docs/agentic-workflow/workflow/testing-strategy.md`
+- `docs/agentic-workflow/tools/codex-cli/skills/scaffold-backend.md` for Phase 1 scaffold work
+
+## Process
+
+1. Confirm the GitHub issue scope, non-goals, acceptance criteria, and validation.
+2. Identify expected tests before or alongside behavior changes.
+3. Preserve Clean Architecture boundaries.
+4. Keep changes inside `apps/api/` unless docs or workflow updates are explicitly needed.
+5. Run validation or document why it cannot be run.
+6. Prepare PR notes with validation evidence and follow-ups.
+
+## Stop Conditions
+
+Stop if the task requires product scope changes, service boundary changes, unapproved infrastructure dependencies, or app architecture changes without an ADR.

--- a/.agents/skills/squadsync-docs-maintenance/SKILL.md
+++ b/.agents/skills/squadsync-docs-maintenance/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: squadsync-docs-maintenance
+description: Use for SquadSync documentation updates, stale link cleanup, documentation headers, root summary sync, and documentation consistency checks.
+---
+
+# SquadSync Docs Maintenance
+
+Use this skill for documentation-focused tasks.
+
+## Required Context
+
+Read first:
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `docs/agentic-workflow/workflow/documentation-standards.md`
+- `docs/agentic-workflow/workflow/root-summary-sync.md`
+- `docs/agentic-workflow/workflow/spec-consistency.md`
+- `docs/agentic-workflow/tools/codex-cli/skills/update-docs.md`
+
+## Process
+
+1. Identify the main reference document before editing.
+2. Check whether README, AGENTS, roadmap, or system overview need matching updates.
+3. Update document headers for meaningful changes to major docs.
+4. Remove stale references when paths or terms change.
+5. Link to canonical docs instead of duplicating long sections.
+6. Report validation performed in the PR.
+
+## Stop Conditions
+
+Stop if docs conflict and the correct reference is unclear, or if the change would alter product scope, architecture, or workflow governance without approval.

--- a/.agents/skills/squadsync-pr-review/SKILL.md
+++ b/.agents/skills/squadsync-pr-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: squadsync-pr-review
+description: Use for reviewing SquadSync pull requests against issue scope, acceptance criteria, validation evidence, architecture boundaries, and follow-up handling.
+---
+
+# SquadSync PR Review
+
+Use this skill for pull request review support.
+
+## Required Context
+
+Read first:
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `docs/agentic-workflow/specs/pull-request-spec.md`
+- `docs/agentic-workflow/workflow/validation-gates.md`
+- `docs/agentic-workflow/tools/codex-cli/skills/review-pr.md`
+- the linked GitHub issue and PR body
+
+## Review Focus
+
+Check whether the PR:
+
+- stays inside scope
+- satisfies acceptance criteria
+- reports validation honestly
+- preserves architecture boundaries
+- updates docs when needed
+- captures follow-up work without expanding scope
+
+## Output
+
+Report blocking issues first, then non-blocking suggestions, validation concerns, architecture concerns, and follow-up issue suggestions.
+
+Do not approve or merge on behalf of the human owner.

--- a/.agents/skills/squadsync-spec-verification/SKILL.md
+++ b/.agents/skills/squadsync-spec-verification/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: squadsync-spec-verification
+description: Use for checking SquadSync documentation consistency before implementation, including pathing, MVP scope, architecture boundaries, and stale references.
+---
+
+# SquadSync Spec Verification
+
+Use this skill when an issue, PR, or implementation plan may depend on conflicting or stale docs.
+
+## Required Context
+
+Read first:
+
+- `AGENTS.md`
+- `docs/agentic-workflow/workflow/spec-consistency.md`
+- `docs/agentic-workflow/workflow/stop-conditions.md`
+- `docs/agentic-workflow/tools/codex-cli/rules/spec-discrepancy-rules.md`
+- relevant planning, architecture, product, and ADR docs
+
+## Process
+
+1. Identify the affected paths and docs.
+2. Compare root summaries and canonical docs.
+3. Flag conflicts before implementation.
+4. Recommend whether to update docs, create an ADR, or ask the human owner.
+
+## Output
+
+Use this structure:
+
+```text
+Conflicting docs:
+Conflict:
+Likely reference:
+Recommended fix:
+Can work continue safely?
+```

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,35 @@
+# Codex Configuration
+
+This directory is reserved for future Codex-native project configuration.
+
+## Current Status
+
+Placeholder only.
+
+No active Codex command policies, executable hooks, MCP configuration, automations, or subagent automation are configured here yet.
+
+## Planned Structure
+
+```text
+.codex/
+  rules/  future native Codex command-policy docs/config
+  hooks/  future native Codex lifecycle hook docs/config
+```
+
+## Relationship to Workflow Docs
+
+Human-readable Codex workflow documentation lives under:
+
+```text
+docs/agentic-workflow/tools/codex-cli/
+```
+
+Repo-native Codex skills live under:
+
+```text
+.agents/skills/
+```
+
+## Rule
+
+Do not add active Codex configuration here until the syntax and behavior are verified in a real Codex environment and the change is issue-backed.

--- a/.codex/hooks/README.md
+++ b/.codex/hooks/README.md
@@ -1,0 +1,27 @@
+# Codex Hooks Placeholder
+
+This directory is reserved for future native Codex lifecycle hook configuration.
+
+## Current Status
+
+Placeholder only. No executable hooks are active yet.
+
+## Important Distinction
+
+Human-readable hook planning lives under:
+
+```text
+docs/agentic-workflow/tools/codex-cli/hooks/
+```
+
+Future native hook configuration may live here after it is tested in Codex and approved through an issue-backed PR.
+
+## Adoption Rule
+
+Add executable hooks only when:
+
+- the manual workflow has repeated enough to justify automation
+- the hook behavior is deterministic
+- the hook can be tested locally
+- the hook reduces review burden
+- the human owner approves the change

--- a/.codex/rules/README.md
+++ b/.codex/rules/README.md
@@ -1,0 +1,26 @@
+# Codex Rules Placeholder
+
+This directory is reserved for future native Codex command-policy rules.
+
+## Current Status
+
+Placeholder only. No active `.rules` files are configured yet.
+
+## Important Distinction
+
+Human-readable Codex behavior rules live under:
+
+```text
+docs/agentic-workflow/tools/codex-cli/rules/
+```
+
+Future native command-policy files may live here after they are tested in Codex and approved through an issue-backed PR.
+
+## Adoption Rule
+
+Add native command-policy rules only when:
+
+- the syntax has been verified in a real Codex environment
+- the rule solves repeated workflow friction
+- the behavior is documented
+- the human owner approves the change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ Before making changes, read the relevant documents:
 
 - `README.md` for repository purpose, current state, and navigation
 - `CONTRIBUTING.md` for issue, branch, PR, and validation rules
+- `PLANS.md` for ExecPlan usage on complex or multi-step work
+- `.agents/README.md` for repo-native agent asset structure
+- `.codex/README.md` for future Codex-native configuration placeholders
 - `docs/planning/project-roadmap.md` for phase and sprint direction
 - `docs/planning/mvp-scope.md` for MVP boundaries
 - `docs/product/product-brief.md` for product direction
@@ -41,6 +44,20 @@ Before making changes, read the relevant documents:
 - `docs/agentic-workflow/tools/codex-cli/skills/README.md` for Codex task playbooks
 - `docs/agentic-workflow/tools/codex-cli/hooks/README.md` for Codex hook structure
 - `docs/agentic-workflow/tools/codex-cli/subagents/README.md` for planned Codex subagent roles
+
+## ExecPlans
+
+Use `PLANS.md` when work is complex, multi-step, cross-cutting, risky, or expected to take multiple implementation passes.
+
+Do not require an ExecPlan for small documentation edits, simple issue fixes, or routine PR reviews.
+
+## Repo-Native Skills
+
+Codex-native repo skills live under `.agents/skills/`.
+
+Human-readable Codex playbooks live under `docs/agentic-workflow/tools/codex-cli/skills/`.
+
+Use native skills for repeatable workflows and use the playbooks for deeper explanation and project-specific context.
 
 ## Working Boundaries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Before changing the repository, read:
 
 - [README.md](README.md)
 - [AGENTS.md](AGENTS.md)
+- [PLANS.md](PLANS.md)
 - [Project Roadmap](docs/planning/project-roadmap.md)
 - [Agentic Workflow Architecture](docs/agentic-workflow/README.md)
 - [Branching Strategy](docs/agentic-workflow/workflow/branching-strategy.md)
@@ -25,6 +26,7 @@ Issue -> short-lived branch -> scoped change -> validation -> pull request -> hu
 - Start from a GitHub issue unless the human owner explicitly approves an emergency direct fix.
 - Keep each branch and PR scoped to one focused change.
 - Use short-lived branches from `main`.
+- Use `PLANS.md` for complex, cross-cutting, risky, or multi-step work.
 - Preserve documented architecture boundaries.
 - Update docs when behavior, architecture, workflow, or scope changes.
 - Run relevant validation or document why validation cannot be run.
@@ -71,5 +73,9 @@ ChatGPT GitHub and Codex CLI workflows are documented under:
 
 - [ChatGPT GitHub Tool Profile](docs/agentic-workflow/tools/chatgpt-github/README.md)
 - [Codex CLI Tool Profile](docs/agentic-workflow/tools/codex-cli/README.md)
+
+Repo-native Codex skills live under:
+
+- [.agents/skills](.agents/skills)
 
 AI tools may assist planning, documentation, implementation, and review, but the human owner retains final authority over architecture, scope, and merge decisions.

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,153 @@
+# SquadSync Execution Plans
+
+## Purpose
+
+This document defines SquadSync's standard for execution plans, called ExecPlans.
+
+An ExecPlan is a living implementation plan for complex, multi-step work. It should be self-contained enough that a human or coding agent can restart the task from the plan without relying on hidden chat history.
+
+## When to Use an ExecPlan
+
+Use an ExecPlan for:
+
+- multi-hour implementation work
+- major feature slices
+- significant refactors
+- cross-cutting changes across `apps/api`, `apps/web`, `infra`, and `docs`
+- risky migrations or architecture changes
+- work that needs milestones, decisions, validation evidence, and recovery notes
+
+Do not require an ExecPlan for:
+
+- small documentation edits
+- simple one-issue code changes
+- routine PR review
+- typo/link fixes
+- small scoped follow-up issues
+
+## Relationship to Issues and PRs
+
+GitHub issues remain the executable work record.
+
+ExecPlans are used when an issue needs more design depth before implementation.
+
+A PR that implements an ExecPlan should link both:
+
+- the GitHub issue
+- the ExecPlan file, if checked into the repository
+
+## Required Sections
+
+Each ExecPlan should include:
+
+```text
+# <Action-oriented title>
+
+## Purpose / Big Picture
+## Progress
+## Surprises & Discoveries
+## Decision Log
+## Outcomes & Retrospective
+## Context and Orientation
+## Plan of Work
+## Concrete Steps
+## Validation and Acceptance
+## Idempotence and Recovery
+## Artifacts and Notes
+## Interfaces and Dependencies
+```
+
+## Living Document Requirements
+
+The `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` sections must be updated as work proceeds.
+
+Each major decision should include:
+
+```text
+Decision:
+Rationale:
+Date/Author:
+```
+
+## Validation Standard
+
+Every ExecPlan must explain how success is proven.
+
+For future API work, expected baseline commands are:
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```
+
+For docs-only work, validation should cover:
+
+- links and paths
+- source-of-truth consistency
+- stale references
+- scope/non-goals
+
+## Safety and Recovery
+
+ExecPlans should prefer additive, reviewable changes. If a step can fail or be repeated, describe how to retry safely.
+
+Do not include destructive operations without an explicit recovery path.
+
+## Minimal Skeleton
+
+```md
+# <Action-oriented title>
+
+This ExecPlan follows `PLANS.md` from the repository root.
+
+## Purpose / Big Picture
+
+Explain what someone gains after this change and how to see it working.
+
+## Progress
+
+- [ ] Initial plan drafted.
+
+## Surprises & Discoveries
+
+- None yet.
+
+## Decision Log
+
+- Decision:
+  Rationale:
+  Date/Author:
+
+## Outcomes & Retrospective
+
+- Not started.
+
+## Context and Orientation
+
+Describe relevant files, paths, terms, and current state.
+
+## Plan of Work
+
+Describe the implementation sequence in prose.
+
+## Concrete Steps
+
+List exact commands and repository paths.
+
+## Validation and Acceptance
+
+Describe tests/checks and expected outcomes.
+
+## Idempotence and Recovery
+
+Explain safe retry/rollback behavior.
+
+## Artifacts and Notes
+
+Capture concise outputs, diffs, or notes that prove progress.
+
+## Interfaces and Dependencies
+
+Name the files, APIs, libraries, and interfaces involved.
+```

--- a/docs/agentic-workflow/tools/codex-cli/skills/README.md
+++ b/docs/agentic-workflow/tools/codex-cli/skills/README.md
@@ -2,19 +2,31 @@
 
 ## Purpose
 
-Skills are reusable Codex task playbooks.
+This directory contains expanded task playbooks for common Codex work in SquadSync.
 
-They describe how Codex should approach common categories of work in SquadSync.
+These playbooks explain how to approach project-specific work in more detail than a short skill trigger file.
 
-## Current Skills
+## Current Playbooks
 
 - `implement-agent-task.md` — default implementation flow for an agent-ready issue.
-- `scaffold-backend.md` — Phase 1 backend scaffold playbook.
+- `scaffold-backend.md` — Phase 1 API scaffold playbook.
 - `update-docs.md` — documentation update playbook.
 - `review-pr.md` — PR review support playbook.
 
+## Repo Skill Location
+
+Short repo skill entry points live under:
+
+```text
+.agents/skills/
+```
+
+Use `.agents/skills/` for concise tool-discoverable instructions.
+
+Use this directory for fuller supporting playbooks.
+
 ## Status
 
-These skills are documentation-based playbooks.
+These files are documentation-based playbooks.
 
-They are not executable automation. They can later be converted into tool-native skill/config files if the project adopts that format.
+They are not executable automation.


### PR DESCRIPTION
## Summary

Aligns SquadSync's Phase 0 harness with official Codex-native planning and skill structure before Phase 1 API implementation begins.

The repo already has human-readable workflow docs under `docs/agentic-workflow/`. This PR adds the missing native Codex-facing layer:

```text
PLANS.md
.agents/skills/
.codex/
```

## Related Issue(s)

Closes #38

## Scope

Adds:

- `PLANS.md`
- `.agents/README.md`
- `.agents/skills/squadsync-api-task/SKILL.md`
- `.agents/skills/squadsync-docs-maintenance/SKILL.md`
- `.agents/skills/squadsync-pr-review/SKILL.md`
- `.agents/skills/squadsync-spec-verification/SKILL.md`
- `.codex/README.md`
- `.codex/rules/README.md`
- `.codex/hooks/README.md`

Updates:

- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/agentic-workflow/tools/codex-cli/skills/README.md`

## Intentional Layering

This PR clarifies the distinction between:

```text
docs/agentic-workflow/
  Human-readable governance, workflow, and tool-profile documentation.

.agents/skills/
  Repo-native Codex skill entry points with SKILL.md files.

PLANS.md
  Root ExecPlan standard for complex, multi-step work.

.codex/
  Placeholder location for future Codex-native configuration areas.
```

## Non-Goals

- No application code.
- No Phase 1 API scaffold.
- No executable hooks/scripts.
- No active subagent automation.
- No MCP server configuration.
- No Codex automations.
- No real native command-policy rule files.
- No deployment or CI changes.

## Acceptance Criteria Status

- [x] Root `PLANS.md` defines when and how to use SquadSync ExecPlans.
- [x] `AGENTS.md` references ExecPlans and repo-native skills.
- [x] `.agents/skills/` contains initial repo-native Codex skills with valid `SKILL.md` files.
- [x] Human-readable Codex skill docs distinguish themselves from native repo skills.
- [x] `.codex/` placeholder structure exists for future native Codex config areas.
- [x] Native config placeholders are clearly non-active.
- [x] No application code, executable hooks, active subagents, MCP config, automations, CI, or deployment artifacts are added.

## Validation

Docs-only validation performed:

- Verified native skills live under `.agents/skills/`.
- Verified human-readable Codex playbooks remain under `docs/agentic-workflow/tools/codex-cli/skills/`.
- Verified `PLANS.md` exists at repo root.
- Verified `.codex/` files are placeholders and do not imply active command policies or executable hooks.
- Verified no application code was added.

Commands run:

```bash
# Not run: documentation-only change; no application scaffold required.
```

## Documentation Impact

- [ ] No documentation changes needed
- [ ] README updated
- [ ] Architecture docs updated
- [ ] ADR created or updated
- [x] Prompt/workflow docs updated

## Architecture Notes

N/A for application architecture.

This PR affects agentic workflow architecture only. It does not change the API/web architecture, MVP scope, or Phase 1 implementation plan.

## Agentic Workflow Notes

- [x] Relevant workflow docs/specs were considered
- [x] Validation gates were run or limitations documented
- [x] Stop conditions were considered
- [x] ADR need was considered

## Suggested Follow-ups

- Test the native skills in an actual Codex session during the first Phase 1 API scaffold task.
- Add or adjust native skills only after real Codex usage exposes friction.
- Add real `.codex/` configuration only after syntax/behavior is verified and the need is proven.
- Consider MCP only after repeated external-context needs appear.

## Review Checklist

- [x] PR stays inside issue scope
- [x] Relevant docs/ADRs were considered
- [x] Tests or validation steps are documented
- [x] Naming is clear and consistent
- [x] Follow-up work is captured if needed